### PR TITLE
MODLD-681: Mark the repository as deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Copyright (C) 2022-2024 The Open Library Foundation
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
+
+## DEPRECATED
+This repository is deprecated because the feature it was intended to implement is not included in the scope of any FOLIO releases. The repository will be reactivated once the feature is prioritized again. [MODLD-681](https://folio-org.atlassian.net/browse/MODLD-681)


### PR DESCRIPTION
[MODLD-681](https://folio-org.atlassian.net/browse/MODLD-681): Mark the repository as deprecated.

This repository was initially created with the assumption that Hubs would be included in the Linked Data graph as part of the Trillium release. However, priorities have shifted, and Hubs are no longer within the scope of Trillium.

The repository may be unarchived after the Trillium release.